### PR TITLE
fix variable naming for docker teststand

### DIFF
--- a/prod/docker_teststand/main.tf
+++ b/prod/docker_teststand/main.tf
@@ -17,18 +17,18 @@ module "docker-teststand" {
   network    = data.terraform_remote_state.vcp.outputs.vpc_network_self_link
   subnetwork = data.terraform_remote_state.vcp.outputs.vpc_subnetwork_self_link[0]
 
-  instance_name                = var.docker-teststand-instance_name
-  zone                         = var.docker-teststand_instance_zone
-  network_ip                   = var.docker-teststand-network_ip
-  instance_type                = var.docker-teststand-instance_type
-  update_stopping              = var.docker-teststand-update_stopping
-  deletion_protection          = var.docker-teststand-deletion_protection
-  labels                       = var.docker-teststand-instance_labels
-  bootdisk_image_size          = var.docker-teststand-bootdisk_image_size
-  image                        = var.docker-teststand-image
-  startup_script               = var.docker-teststand-startup_script
-  assign_ephemeral_external_ip = var.docker-teststand-assign_ephemeral_external_ip
-  tags                         = [var.docker-teststand-instance_name]
+  instance_name                = var.docker_teststand_instance_name
+  zone                         = var.docker_teststand_instance_zone
+  network_ip                   = var.docker_teststand_network_ip
+  instance_type                = var.docker_teststand_instance_type
+  update_stopping              = var.docker_teststand_update_stopping
+  deletion_protection          = var.docker_teststand_deletion_protection
+  labels                       = var.docker_teststand_instance_labels
+  bootdisk_image_size          = var.docker_teststand_bootdisk_image_size
+  image                        = var.docker_teststand_image
+  startup_script               = var.docker_teststand_startup_script
+  assign_ephemeral_external_ip = var.docker_teststand_assign_ephemeral_external_ip
+  tags                         = [var.docker_teststand_instance_name]
 }
 
 
@@ -41,7 +41,7 @@ module "docker-teststand_firewall" {
   firewall_name = "docker-teststand-firewall-rules"
   network       = data.terraform_remote_state.vcp.outputs.vpc_network_self_link
   source_ranges = ["0.0.0.0/0"]
-  target_tags   = [var.docker-teststand-instance_name]
+  target_tags   = [var.docker_teststand_instance_name]
 
   allow_rules = [
     {

--- a/prod/docker_teststand/variables.tf
+++ b/prod/docker_teststand/variables.tf
@@ -1,63 +1,63 @@
 # DOCKER-TESTSTAND variables
-variable "docker-teststand-update_stopping" {
+variable "docker_teststand_update_stopping" {
   type    = bool
   default = true
 }
 
-variable "docker-teststand-deletion_protection" {
+variable "docker_teststand_deletion_protection" {
   type    = bool
   default = false
 }
 
-variable "docker-teststand-instance_name" {
+variable "docker_teststand_instance_name" {
   type    = string
   default = "docker-teststand"
 }
 
-variable "docker-teststand_instance_zone" {
+variable "docker_teststand_instance_zone" {
   type    = string
   default = "us-central1-f"
 }
 
-variable "docker-teststand-network_ip" {
+variable "docker_teststand_network_ip" {
   type    = string
   default = "10.10.10.5"
 }
 
-variable "docker-teststand-instance_type" {
+variable "docker_teststand_instance_type" {
   type    = string
   default = "e2-standard-4"
 }
 
-variable "docker-teststand-instance_labels" {
+variable "docker_teststand_instance_labels" {
   type = map(string)
   default = {
     "purpose" = "docker"
   }
 }
 
-variable "docker-teststand-bootdisk_image_size" {
+variable "docker_teststand_bootdisk_image_size" {
   type    = number
   default = 30
 }
 
-variable "docker-teststand-image" {
+variable "docker_teststand_image" {
   type    = string
   default = "projects/ubuntu-os-cloud/global/images/ubuntu-minimal-2504-plucky-amd64-v20250430"
 }
 
-variable "docker-teststand-assign_ephemeral_external_ip" {
+variable "docker_teststand_assign_ephemeral_external_ip" {
   type    = bool
   default = true
 }
 
-variable "docker-teststand-startup_script" {
+variable "docker_teststand_startup_script" {
   type        = string
   description = "commands for startup"
   default     = <<-EOF
     #!/bin/bash
     set -e
-    
+
     apt update && apt upgrade -y
     apt install docker-compose-v2 vim htop mc -y
   EOF


### PR DESCRIPTION
## Summary
- use underscores in docker_teststand variable names to satisfy Terraform naming rules
- update references in docker_teststand module

## Testing
- `terraform validate` *(fails: command not found)*
- `apt-get update` *(fails: repository ... not signed)*

------
https://chatgpt.com/codex/tasks/task_e_6898827596b8832ca102babcee525664